### PR TITLE
build: remove deprecated health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,4 @@ EXPOSE 4224
 
 STOPSIGNAL SIGINT
 
-HEALTHCHECK CMD curl -fSs http://localhost:4224/ || exit 1
-
 ENTRYPOINT ["/usr/bin/electrs"]


### PR DESCRIPTION
fixes electrs container marked as "unhealthy"